### PR TITLE
Feature/single tenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ dbt_cloud_job_runner_config = dbt_cloud_job_runner(
 
 ```
 
-> :exclamation: **If you are on a [Single Tenant](https://docs.getdbt.com/docs/dbt-cloud/deployments/deployment-overview) instance of dbt Cloud:** Add the optional parameter `single_tenant` with your single tenant subdomain(s). For example:
+> :exclamation: **If you are on a [Single Tenant](https://docs.getdbt.com/docs/dbt-cloud/deployments/deployment-overview) instance of dbt Cloud:** Add the optional parameter `tenant` with your single tenant subdomain(s). For example:
 
 ```
 dbt_cloud_job_runner_config = dbt_cloud_job_runner(
-    single_tenant = 'customer', account_id=19, project_id=37, job_id=28, cause=dag_file_name
+    tenant = 'customer', account_id=19, project_id=37, job_id=28, cause=dag_file_name
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ dbt_cloud_job_runner_config = dbt_cloud_job_runner(
 
 ```
 dbt_cloud_job_runner_config = dbt_cloud_job_runner(
-    single_tenant = 'customer', account_id=16173, project_id=36467, job_id=30605, cause=dag_file_name
+    single_tenant = 'customer', account_id=19, project_id=37, job_id=28, cause=dag_file_name
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ dbt_cloud_job_runner_config = dbt_cloud_job_runner(
 
 ```
 
+> :exclamation: **If you are on a [Single Tenant](https://docs.getdbt.com/docs/dbt-cloud/deployments/deployment-overview) instance of dbt Cloud:** Add the optional parameter `single_tenant` with your single tenant subdomain(s). For example:
+
+```
+dbt_cloud_job_runner_config = dbt_cloud_job_runner(
+    single_tenant = 'customer', account_id=16173, project_id=36467, job_id=30605, cause=dag_file_name
+)
+```
+
 Turn on the DAG:
 ![image](/images/turn_on_dag.png)
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ dbt_cloud_job_runner_config = dbt_cloud_job_runner(
 
 ```
 
-
 Turn on the DAG:
 ![image](/images/turn_on_dag.png)
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Add your dbt Cloud API token as an encrypted variable:
 
 Add your job config details to the python file: [dbt_cloud_example.py](/dags/dbt_cloud_example.py)
 
+> :exclamation: **If you are on a [Single Tenant](https://docs.getdbt.com/docs/dbt-cloud/deployments/deployment-overview) instance of dbt Cloud:** Add the optional parameter `tenant` with your single tenant subdomain(s) as demonstrated in [dbt_cloud_example_single_tenant.py](/dags/dbt_cloud_example_single_tenant.py).
+
 ```python
 # TODO: MANUALLY create a dbt Cloud job: https://docs.getdbt.com/docs/dbt-cloud/cloud-quickstart#create-a-new-job
 # Example dbt Cloud job URL
@@ -92,13 +94,6 @@ dbt_cloud_job_runner_config = dbt_cloud_job_runner(
 
 ```
 
-> :exclamation: **If you are on a [Single Tenant](https://docs.getdbt.com/docs/dbt-cloud/deployments/deployment-overview) instance of dbt Cloud:** Add the optional parameter `tenant` with your single tenant subdomain(s). For example:
-
-```
-dbt_cloud_job_runner_config = dbt_cloud_job_runner(
-    tenant = 'customer', account_id=19, project_id=37, job_id=28, cause=dag_file_name
-)
-```
 
 Turn on the DAG:
 ![image](/images/turn_on_dag.png)

--- a/dags/dbt_cloud_example_single_tenant.py
+++ b/dags/dbt_cloud_example_single_tenant.py
@@ -1,0 +1,46 @@
+from airflow import DAG
+from datetime import datetime
+from airflow.operators.dummy import DummyOperator
+from airflow.operators.python_operator import PythonOperator
+from dbt_cloud_utils import dbt_cloud_job_runner
+
+
+dag_file_name = __file__
+
+# TODO: MANUALLY create a dbt Cloud job: https://docs.getdbt.com/docs/dbt-cloud/cloud-quickstart#create-a-new-job
+# Example dbt Cloud job URL
+# https://cloud.getdbt.com/#/accounts/4238/projects/12220/jobs/12389/
+# example dbt Cloud job config
+dbt_cloud_job_runner_config = dbt_cloud_job_runner(
+    account_id=1, project_id=195, job_id=35, tenant="staging.singletenant", cause=dag_file_name
+)
+
+
+default_args = {
+    "owner": "airflow",
+    "email": ["airflow@example.com"],
+    "depends_on_past": False,
+    "start_date": datetime(2001, 1, 1),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "priority_weight": 1000,
+}
+
+
+with DAG(
+    "dbt_cloud_example", default_args=default_args, schedule_interval="@once"
+) as dag:
+    # have a separate extract and load process(think: FivetranOperator and/or custom gcs load to bigquery tasks)
+    extract = DummyOperator(task_id="extract")
+    load = DummyOperator(task_id="load")
+    ml_training = DummyOperator(task_id="ml_training")
+
+    # Single task to execute dbt Cloud job and track status over time
+    transform = PythonOperator(
+        task_id="run-dbt-cloud-job",
+        python_callable=dbt_cloud_job_runner_config.run_job,
+        provide_context=True,
+    )
+
+    extract >> load >> transform >> ml_training

--- a/dags/dbt_cloud_example_single_tenant.py
+++ b/dags/dbt_cloud_example_single_tenant.py
@@ -29,7 +29,7 @@ default_args = {
 
 
 with DAG(
-    "dbt_cloud_example", default_args=default_args, schedule_interval="@once"
+    "dbt_cloud_example_single_tenant", default_args=default_args, schedule_interval="@once"
 ) as dag:
     # have a separate extract and load process(think: FivetranOperator and/or custom gcs load to bigquery tasks)
     extract = DummyOperator(task_id="extract")

--- a/dags/dbt_cloud_example_single_tenant.py
+++ b/dags/dbt_cloud_example_single_tenant.py
@@ -8,8 +8,8 @@ from dbt_cloud_utils import dbt_cloud_job_runner
 dag_file_name = __file__
 
 # TODO: MANUALLY create a dbt Cloud job: https://docs.getdbt.com/docs/dbt-cloud/cloud-quickstart#create-a-new-job
-# Example dbt Cloud job URL
-# https://cloud.getdbt.com/#/accounts/4238/projects/12220/jobs/12389/
+# Example single tenant dbt Cloud job URL
+# https://staging.singletenant.getdbt.com/#/accounts/1/projects/195/jobs/35/
 # example dbt Cloud job config
 dbt_cloud_job_runner_config = dbt_cloud_job_runner(
     account_id=1, project_id=195, job_id=35, tenant="staging.singletenant", cause=dag_file_name

--- a/dags/dbt_cloud_utils.py
+++ b/dags/dbt_cloud_utils.py
@@ -17,14 +17,14 @@ class dbt_cloud_job_vars:
     project_id: int
     job_id: int
     cause: str
-    single_tenant: str = "cloud"
+    tenant: str = "cloud"
     dbt_cloud_api_key: str = Variable.get(
         "dbt_cloud_api_key"
     )  # TODO: manually set this in the airflow variables UI 
 
     @property
     def dbt_cloud_url(self):
-        return f"https://{self.single_tenant}.getdbt.com"
+        return f"https://{self.tenant}.getdbt.com"
 
 
 @dataclass(frozen=True)
@@ -50,7 +50,7 @@ class dbt_cloud_job_runner(dbt_cloud_job_vars, dbt_job_run_status):
         project_id(int): dbt Cloud project id
         job_id(int): dbt Cloud job id
         cause(str): dbt Cloud cause(ex: name of DAG)
-        single_tenant(str): dbt Cloud single tenant subdomain(s) (optional)
+        tenant(str): dbt Cloud single tenant subdomain(s) (optional)
         dbt_cloud_api_key(str)(OPTIONAL): dbt Cloud api key to authorize programmatically interacting with dbt Cloud
     """
 

--- a/dags/dbt_cloud_utils.py
+++ b/dags/dbt_cloud_utils.py
@@ -17,14 +17,14 @@ class dbt_cloud_job_vars:
     project_id: int
     job_id: int
     cause: str
-    single_tenant: str = None
+    single_tenant: str = "cloud"
     dbt_cloud_api_key: str = Variable.get(
         "dbt_cloud_api_key"
     )  # TODO: manually set this in the airflow variables UI 
 
     @property
     def dbt_cloud_url(self):
-        return "https://cloud.getdbt.com" if self.single_tenant is None else f"https://{self.single_tenant}.getdbt.com"
+        return f"https://{self.single_tenant}.getdbt.com"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Description
Provide Single Tenant support in `dbt_cloud_utils` by dynamically building the dbt Cloud instance URL. Add a `tenant` field to `dbt_cloud_job_vars` which defaults to `cloud` or populates URL with single tenant subdomain(s) if passed.

## Python tests
Tests were executed from my local Airflow project using `dbt_cloud_example.py` [lines 14-16](https://github.com/sungchun12/airflow-dbt-cloud/blob/68d18b4cab47f56fa2e3ffff269fe94b7d4185f2/dags/dbt_cloud_example.py#L14-L16) configured as follows:

#### Single Tenant

```
dbt_cloud_job_runner_config = dbt_cloud_job_runner(
    account_id=1, project_id=195, job_id=35, tenant="staging.singletenant", cause=dag_file_name
)
```

#### Multi Tenant

```
dbt_cloud_job_runner_config = dbt_cloud_job_runner(
    account_id=51798, project_id=89133, job_id=74765, cause=dag_file_name
)
```

### Screenshots

### Airflow triggered for Single Tenant
![Screen Shot 2022-04-06 at 11 11 34 AM](https://user-images.githubusercontent.com/20958052/162040745-7fd132f2-96cc-47d0-8f80-8faef1a7308e.png)

### Airflow triggered for Multi Tenant
![Screen Shot 2022-04-06 at 11 11 28 AM](https://user-images.githubusercontent.com/20958052/162040753-321010be-00e3-4d65-82d1-4dbd63b2b050.png)
